### PR TITLE
[SEINE] sepolicy_platform: Replace sysfs_usb_supply with sysfs_batteryinfo

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -30,6 +30,6 @@ genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-01/800f000.q
 
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qcom,pm660_rtc/rtc/rtc0                  u:object_r:sysfs_rtc:s0
 
-genfscon sysfs /devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type                                                    u:object_r:sysfs_usb_supply:s0
+genfscon sysfs /devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type                                                    u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qpnp,fg/power_supply                  u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qcom,qpnp-smb2/power_supply           u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
sysfs_usb_supply is a custom file type serving the same purpose as
sysfs_batteryinfo from AOSP, which at the same time is already granted
read access to relevant domains such as hal_health_default.
Replace this property to normalize policy with other battery/power
related files.