### PR TITLE
[SEINE] [DO-NOT-MERGE] Fix fstab, usb and HALs

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -111,6 +111,10 @@ BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_PRODUCTIMAGE_JOURNAL_SIZE := 0
 BOARD_PRODUCTIMAGE_EXTFS_INODE_COUNT := 4096
 
+# This platform has a metadata partition: declare this
+# to create a mount point for it
+BOARD_USES_METADATA_PARTITION := true
+
 BOARD_AVB_ENABLE := true
 BOARD_AVB_VBMETA_SYSTEM := system
 BOARD_AVB_VBMETA_SYSTEM_KEY_PATH ?= external/avb/test/data/testkey_rsa2048.pem

--- a/platform.mk
+++ b/platform.mk
@@ -124,19 +124,19 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    sound_trigger.primary.sdm660 \
-    audio.primary.sdm660
+    sound_trigger.primary.sm6125 \
+    audio.primary.sm6125
 
 # GFX
 PRODUCT_PACKAGES += \
-    copybit.sdm660 \
-    gralloc.sdm660 \
-    hwcomposer.sdm660 \
-    memtrack.sdm660
+    copybit.sm6125 \
+    gralloc.sm6125 \
+    hwcomposer.sm6125 \
+    memtrack.sm6125
 
 # GPS
 PRODUCT_PACKAGES += \
-    gps.sdm660
+    gps.sm6125
 
 # Sensors
 PRODUCT_PACKAGES += \
@@ -145,7 +145,7 @@ PRODUCT_PACKAGES += \
 
 # CAMERA
 PRODUCT_PACKAGES += \
-    camera.sdm660
+    camera.sm6125
 
 # QCOM Bluetooth
 PRODUCT_PACKAGES += \

--- a/platform.mk
+++ b/platform.mk
@@ -174,7 +174,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
-    sys.usb.controller=a800000.dwc3 \
+    sys.usb.controller=4e00000.dwc3 \
     sys.usb.rndis.func.name=rndis_bam
 
 #WiFi MAC address path

--- a/platform.mk
+++ b/platform.mk
@@ -187,3 +187,4 @@ TARGET_NEEDS_DTBOIMAGE ?= true
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -1,10 +1,16 @@
 # Android fstab file.
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# Logical partitions
 system                                                  /system                   ext4    ro,barrier=1,discard                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey
 product                                                 /product                  ext4    ro,barrier=1,discard                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
 vendor                                                  /vendor                   ext4    ro,barrier=1,discard                                 wait,slotselect,avb,logical,first_stage_mount
 
+# Real first stage mount partitions
+/dev/block/by-name/metadata                /metadata             ext4     noatime,nosuid,nodev,discard                                         wait,formattable,wrappedkey,first_stage_mount
+
+#
 /dev/block/bootdevice/by-name/oem_a        /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -9,9 +9,9 @@ vendor                                     /vendor               ext4     ro,bar
 
 # Real first stage mount partitions
 /dev/block/by-name/metadata                /metadata             ext4     noatime,nosuid,nodev,discard                                         wait,formattable,first_stage_mount
+/dev/block/by-name/oem_a                   /odm                  ext4     ro,barrier=1                                                         wait,first_stage_mount
 
 # Other partitions
-/dev/block/bootdevice/by-name/oem_a        /odm                  ext4     ro,barrier=1                                                         wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic  latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M,checkpoint=block
 /dev/block/bootdevice/by-name/frp          /persistent           emmc     defaults                                                             defaults
 /dev/block/bootdevice/by-name/dsp_a        /vendor/dsp           ext4     nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic          wait,notrim

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -3,23 +3,26 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 # Logical partitions
-system                                                  /system                   ext4    ro,barrier=1,discard                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey
-product                                                 /product                  ext4    ro,barrier=1,discard                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
-vendor                                                  /vendor                   ext4    ro,barrier=1,discard                                 wait,slotselect,avb,logical,first_stage_mount
+system                                     /system               ext4     ro,barrier=1,discard                                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey
+product                                    /product              ext4     ro,barrier=1,discard                                                 wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
+vendor                                     /vendor               ext4     ro,barrier=1,discard                                                 wait,slotselect,avb,logical,first_stage_mount
 
 # Real first stage mount partitions
 /dev/block/by-name/metadata                /metadata             ext4     noatime,nosuid,nodev,discard                                         wait,formattable,wrappedkey,first_stage_mount
 
-#
-/dev/block/bootdevice/by-name/oem_a        /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
-/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/dsp_a        /vendor/dsp             ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
-/dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/modem_a      /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
-/dev/block/bootdevice/by-name/bluetooth_a  /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
-/dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
+# Other partitions
+/dev/block/bootdevice/by-name/oem_a        /odm                  ext4     ro,barrier=1                                                         wait,recoveryonly
+/dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/frp          /persistent           emmc     defaults                                                             defaults
+/dev/block/bootdevice/by-name/dsp_a        /vendor/dsp           ext4     nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic          wait,notrim
+/dev/block/bootdevice/by-name/misc         /misc                 emmc     defaults                                                             defaults
+/dev/block/bootdevice/by-name/modem_a      /vendor/firmware_mnt  vfat     ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
+/dev/block/bootdevice/by-name/bluetooth_a  /vendor/bt_firmware   vfat     ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
+/dev/block/bootdevice/by-name/persist      /mnt/vendor/persist   ext4     noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic  wait,notrim
 
-/devices/platform/soc/c084000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                         voldmanaged=usb:auto
-/dev/block/zram0                            none        swap    defaults                                                      zramsize=1073741824,max_comp_streams=8
+# ZRAM/SWAP
+/dev/block/zram0                           none                  swap     defaults                                                             zramsize=1073741824,max_comp_streams=8
+
+# External devices
+/devices/platform/soc/c084000.sdhci/mmc_host/mmc* auto           auto     nosuid,nodev                                                         voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb* auto auto defaults                                                       voldmanaged=usb:auto

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -24,5 +24,5 @@ vendor                                     /vendor               ext4     ro,bar
 /dev/block/zram0                           none                  swap     defaults                                                             zramsize=1073741824,max_comp_streams=8
 
 # External devices
-/devices/platform/soc/c084000.sdhci/mmc_host/mmc* auto           auto     nosuid,nodev                                                         voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/soc/4784000.sdhci/mmc_host/mmc*     auto       auto     nosuid,nodev                                                         voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/soc/*.ssusb/*.dwc3/xhci-hcd.*.auto* auto       auto     defaults                                                             voldmanaged=usb:auto

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -8,11 +8,11 @@ product                                    /product              ext4     ro,bar
 vendor                                     /vendor               ext4     ro,barrier=1,discard                                                 wait,slotselect,avb,logical,first_stage_mount
 
 # Real first stage mount partitions
-/dev/block/by-name/metadata                /metadata             ext4     noatime,nosuid,nodev,discard                                         wait,formattable,wrappedkey,first_stage_mount
+/dev/block/by-name/metadata                /metadata             ext4     noatime,nosuid,nodev,discard                                         wait,formattable,first_stage_mount
 
 # Other partitions
 /dev/block/bootdevice/by-name/oem_a        /odm                  ext4     ro,barrier=1                                                         wait,recoveryonly
-/dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic  latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M,checkpoint=block
 /dev/block/bootdevice/by-name/frp          /persistent           emmc     defaults                                                             defaults
 /dev/block/bootdevice/by-name/dsp_a        /vendor/dsp           ext4     nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic          wait,notrim
 /dev/block/bootdevice/by-name/misc         /misc                 emmc     defaults                                                             defaults

--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -25,4 +25,4 @@ vendor                                     /vendor               ext4     ro,bar
 
 # External devices
 /devices/platform/soc/c084000.sdhci/mmc_host/mmc* auto           auto     nosuid,nodev                                                         voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb* auto auto defaults                                                       voldmanaged=usb:auto
+/devices/platform/soc/*.ssusb/*.dwc3/xhci-hcd.*.auto* auto       auto     defaults                                                             voldmanaged=usb:auto


### PR DESCRIPTION
This patchset finishes the last early porting bits for the Seine platform:
renames the HALs from sdm660 (?!?!? :))) ) to sm6125, fixes the USB
node for Android's management (hello, adb!) and gives the last shot
to the fstab for this platform.

One note: the commits in here are all perfectly ok, but it's still a big
DO NOT MERGE -- because there may be some issue with checkpointing.

Testing ongoing.... 