### PR TITLE
[SEINE] sepolicy: Label new subsystems and metadata partition

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -33,6 +33,9 @@
 /dev/block/platform/soc/4744000\.sdhci/by-name/userdata         u:object_r:userdata_block_device:s0
 /dev/block/bootdevice/by-name/userdata                          u:object_r:userdata_block_device:s0
 
+/dev/block/platform/soc/4744000\.sdhci/by-name/metadata         u:object_r:metadata_block_device:s0
+/dev/block/bootdevice/by-name/metadata                          u:object_r:metadata_block_device:s0
+
 /dev/block/platform/soc/4744000\.sdhci/by-name/boot_[ab]        u:object_r:boot_block_device:s0
 /dev/block/bootdevice/by-name/boot_[ab]                         u:object_r:boot_block_device:s0
 

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -9,6 +9,7 @@ genfscon sysfs /devices/platform/soc/5e00000.qcom,mdss_rotator                  
 genfscon sysfs /devices/platform/soc/6080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/ab00000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/b300000.qcom,turing                         u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                            u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/5c0c000.qcom,cci                            u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/5c1c000.qcom,jpeg                           u:object_r:sysfs_camera:s0

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,13 +1,14 @@
+genfscon sysfs /devices/platform/soc/1c40000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/4a84000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/4a88000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/4a8c000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/5900000.qcom,kgsl-3d0                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/ab00000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/5ae0000.qcom,venus                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/5e00000.qcom,mdss_mdp                       u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/5e00000.qcom,mdss_rotator                   u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/6080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/1c40000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/5ae0000.qcom,venus                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/ab00000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/b300000.qcom,turing                         u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/5c0c000.qcom,cci                            u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/5c1c000.qcom,jpeg                           u:object_r:sysfs_camera:s0
@@ -24,4 +25,3 @@ genfscon sysfs /devices/platform/soc/1c40000.qcom,spmi/spmi-0/spmi0-00/1c40000.q
 
 genfscon sysfs /devices/platform/soc/1c40000.qcom,spmi/spmi-0/spmi0-02/1c40000.qcom,spmi:qcom,pmi632@2:qcom,qpnp-smb5/power_supply         u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/1c40000.qcom,spmi/spmi-0/spmi0-02/1c40000.qcom,spmi:qcom,pmi632@2:qpnp,qg/power_supply                u:object_r:sysfs_batteryinfo:s0
-


### PR DESCRIPTION
Seine has `ipa_fws` and `turing` just like Tama and Kumano. Furthermore, label the new `metadata` partition.

Note that this doesn't fully cover all denials yet, there's still something unexpected going on with init and block devices. To be continued...