### PR TITLE
[SEINE] platform: Build libcirrusspkrprot

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -124,7 +124,8 @@ PRODUCT_PACKAGES += \
 # Audio
 PRODUCT_PACKAGES += \
     sound_trigger.primary.sm6125 \
-    audio.primary.sm6125
+    audio.primary.sm6125 \
+    libcirrusspkrprot
 
 # GFX
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
The CAF HAL gates all features behind... A build flag, one or more
runtime properties, and a separate library instead of linking directly
into audio.primary. Enable building the cirrus audio_extn library.
