### PR TITLE
[3/3] [SEINE] PlatformConfig: Remove NO_FPC

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -133,7 +133,5 @@ BOARD_AVB_VBMETA_SYSTEM_ROLLBACK_INDEX_LOCATION := 1
 TARGET_NO_RECOVERY := false
 BOARD_USES_RECOVERY_AS_BOOT := false
 
-TARGET_DEVICE_NO_FPC := true
-
 include device/sony/common/CommonConfig.mk
 


### PR DESCRIPTION
The Egistec fingerprint sensor on Seine is configured in the following
PRs:
https://github.com/sonyxperiadev/kernel/pull/2319
https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/69
Remove this guard to allow building and using the HAL.
