### PR TITLE
[SEINE] Properly configure Wi-Fi features and solve sleep drop

### DIFF
--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -1,3 +1,4 @@
 disable_scan_offload=1
 p2p_disabled=1
 tdls_external_control=1
+wowlan_triggers=magic_pkt

--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -2,6 +2,7 @@ disable_scan_offload=1
 p2p_disabled=1
 tdls_external_control=1
 wowlan_triggers=magic_pkt
+bss_max_count=512
 hs20=1
 interworking=1
 auto_interworking=0

--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -2,3 +2,6 @@ disable_scan_offload=1
 p2p_disabled=1
 tdls_external_control=1
 wowlan_triggers=magic_pkt
+hs20=1
+interworking=1
+auto_interworking=0


### PR DESCRIPTION
This patchset enables the IEEE 802.11u Interworking, a feature in Wi-Fi Hotspot 2.0, enables the magic packet WoWLAN trigger to stop disconnections during deep sleep and enhances user experience by limiting the BSS entries to keep in memory to a "virtually decent" number (it can be lower, but that's the maximum after which performance degrades).