### PR TITLE
[SEINE] Give block devices more specific labels for fastbootd

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -105,4 +105,7 @@
 /dev/block/platform/soc/4744000\.sdhci/by-name/xbl_[ab]         u:object_r:xbl_block_device:s0
 /dev/block/bootdevice/by-name/xbl_[ab]                          u:object_r:xbl_block_device:s0
 
+/dev/block/platform/soc/4744000\.sdhci/by-name/super            u:object_r:super_block_device:s0
+/dev/block/bootdevice/by-name/super                             u:object_r:super_block_device:s0
+
 /dev/block/zram0                                                u:object_r:swap_block_device:s0

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -39,6 +39,9 @@
 /dev/block/platform/soc/4744000\.sdhci/by-name/boot_[ab]        u:object_r:boot_block_device:s0
 /dev/block/bootdevice/by-name/boot_[ab]                         u:object_r:boot_block_device:s0
 
+/dev/block/platform/soc/4744000\.sdhci/by-name/recovery_[ab]    u:object_r:recovery_block_device:s0
+/dev/block/bootdevice/by-name/recovery_[ab]                     u:object_r:recovery_block_device:s0
+
 /dev/block/platform/soc/4744000\.sdhci/by-name/misc             u:object_r:misc_block_device:s0
 /dev/block/bootdevice/by-name/misc                              u:object_r:misc_block_device:s0
 

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -108,4 +108,10 @@
 /dev/block/platform/soc/4744000\.sdhci/by-name/super            u:object_r:super_block_device:s0
 /dev/block/bootdevice/by-name/super                             u:object_r:super_block_device:s0
 
+/dev/block/platform/soc/4744000\.sdhci/by-name/dtbo_[ab]        u:object_r:dtbo_block_device:s0
+/dev/block/bootdevice/by-name/dtbo_[ab]                         u:object_r:dtbo_block_device:s0
+
+/dev/block/platform/soc/4744000\.sdhci/by-name/vbmeta(_system)?_[ab]    u:object_r:vbmeta_block_device:s0
+/dev/block/bootdevice/by-name/vbmeta(_system)?_[ab]                     u:object_r:vbmeta_block_device:s0
+
 /dev/block/zram0                                                u:object_r:swap_block_device:s0


### PR DESCRIPTION
Fastbootd requires devices to be properly labeled, it is not allowed to flash the default "unspecified" block_device and shouldn't be. Label all flashable partitions that weren't labeled properly yet: `recovery`, `dtbo`, `vbmeta(_system)`, and most importantly to use fastbootd at all: `super`.

@jerpelea now we can suggest/allow users to flash recovery in the guide :tada:
