### PR TITLE
[SEINE] Update NFC names and configuration

### DIFF
--- a/rootdir/vendor/etc/libnfc-nci.conf
+++ b/rootdir/vendor/etc/libnfc-nci.conf
@@ -2,10 +2,7 @@
 
 ###############################################################################
 # Application options
-APPL_TRACE_LEVEL=0xFF
-PROTOCOL_TRACE_LEVEL=0xFFFFFFFF
-
-NFC_DEBUG_ENABLED=0x01
+NFC_DEBUG_ENABLED=0
 
 ###############################################################################
 # File used for NFA storage

--- a/rootdir/vendor/etc/libnfc-nci.conf
+++ b/rootdir/vendor/etc/libnfc-nci.conf
@@ -1,16 +1,41 @@
+###################### Start of libnfc-brcm.conf #######################
+
 ###############################################################################
 # Application options
-NFC_DEBUG_ENABLED=0
+APPL_TRACE_LEVEL=0xFF
+PROTOCOL_TRACE_LEVEL=0xFFFFFFFF
+
+NFC_DEBUG_ENABLED=0x01
 
 ###############################################################################
 # File used for NFA storage
-NFA_STORAGE="/data/vendor/nfc"
+NFA_STORAGE="/data/nfc"
+
+###############################################################################
+# Configure the default Destination Gate used by HCI (the default is 4, which
+# is the ETSI loopback gate.
+NFA_HCI_DEFAULT_DEST_GATE=0xF0
 
 ###############################################################################
 # Force UICC to only listen to the following technology(s).
 # The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
 # Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B | NFA_TECHNOLOGY_MASK_F
 UICC_LISTEN_TECH_MASK=0x07
+
+###############################################################################
+# Forcing HOST to listen for a selected protocol
+# 0x00 : Disable Host Listen
+# 0x01 : Enable Host to Listen (A)  for ISO-DEP tech A
+# 0x02 : Enable Host to Listen (B)  for ISO-DEP tech B
+# 0x04 : Enable Host to Listen (F)  for T3T Tag Type Protocol tech F
+# 0x07 : Enable Host to Listen (ABF)for ISO-DEP tech AB & T3T Tag Type Protocol tech F
+HOST_LISTEN_TECH_MASK=0x07
+
+###############################################################################
+# Enabling/Disabling Forward functionality
+# Disable           0x00
+# Enable            0x01
+NXP_FWD_FUNCTIONALITY_ENABLE=0x00
 
 ###############################################################################
 # AID for Empty Select command
@@ -26,21 +51,57 @@ AID_FOR_EMPTY_SELECT={08:A0:00:00:01:51:00:00:00}
 SCREEN_OFF_POWER_STATE=1
 
 ###############################################################################
-# Override the stack default for NFA_EE_MAX_EE_SUPPORTED set in nfc_target.h.
-# The value is set to 3 by default as it assumes we will discover 0xF2,
-# 0xF3, and 0xF4. If a platform will exclude and SE, this value can be reduced
-# so that the stack will not wait any longer than necessary.
+# Default poll duration (in ms)
+#  The defualt is 500ms if not set (see nfc_target.h)
+NFA_DM_DISC_DURATION_POLL=300
 
-# Maximum EE supported number
-# NXP PN547C2 0x02
-# NXP PN65T 0x03
-# NXP PN548C2 0x02
-# NXP PN66T 0x03
-NFA_MAX_EE_SUPPORTED=0x02
+###############################################################################
+# Force tag polling for the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B |
+#            NFA_TECHNOLOGY_MASK_F | NFA_TECHNOLOGY_MASK_ISO15693 |
+#            NFA_TECHNOLOGY_MASK_B_PRIME | NFA_TECHNOLOGY_MASK_KOVIO |
+#NFA_TECHNOLOGY_MASK_ACTIVE
+#
+# Notable bits:
+# NFA_TECHNOLOGY_MASK_A             0x01    /* NFC Technology A             */
+# NFA_TECHNOLOGY_MASK_B             0x02    /* NFC Technology B             */
+# NFA_TECHNOLOGY_MASK_F             0x04    /* NFC Technology F             */
+# NFA_TECHNOLOGY_MASK_ISO15693      0x08    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_KOVIO         0x20    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_ACTIVE        0x40    /* NFC Technology Active        */
+POLLING_TECH_MASK=0x2F
+
+###############################################################################
+# Force P2P to only listen for the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_F |
+#NFA_TECHNOLOGY_MASK_ACTIVE
+#
+# Notable bits:
+# NFA_TECHNOLOGY_MASK_A             0x01    /* NFC Technology A             */
+# NFA_TECHNOLOGY_MASK_F             0x04    /* NFC Technology F             */
+#NFA_TECHNOLOGY_MASK_ACTIVE         0x40    /* NFC Technology Active        */
+P2P_LISTEN_TECH_MASK=0x05
+
+PRESERVE_STORAGE=0x01
+
+###############################################################################
+# Deactivate notification wait time out in seconds used in ETSI Reader mode
+# 0 - Infinite wait
+NFA_DM_DISC_NTF_TIMEOUT=100
 
 ###############################################################################
 # AID_MATCHING constants
 # AID_MATCHING_EXACT_ONLY 0x00
 # AID_MATCHING_EXACT_OR_PREFIX 0x01
 # AID_MATCHING_PREFIX_ONLY 0x02
-AID_MATCHING_MODE=0x01
+# AID_MATCHING_EXACT_OR_SUBSET_OR_PREFIX 0x03
+AID_MATCHING_MODE=0x03
+
+###############################################################################
+#Set the default Felica T3T System Code :
+#This settings will be used when application does not set this parameter
+DEFAULT_SYS_CODE={FE:FE}
+
+###############################################################################

--- a/rootdir/vendor/etc/libnfc-nci.conf
+++ b/rootdir/vendor/etc/libnfc-nci.conf
@@ -6,7 +6,7 @@ NFC_DEBUG_ENABLED=0
 
 ###############################################################################
 # File used for NFA storage
-NFA_STORAGE="/data/nfc"
+NFA_STORAGE="/data/vendor/nfc"
 
 ###############################################################################
 # Configure the default Destination Gate used by HCI (the default is 4, which

--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -149,7 +149,7 @@ firmware_directories /vendor/firmware_mnt/image/
 /dev/ttyMSM0                                0660 bluetooth bluetooth
 
 # NFC
-/dev/pn54x                                             0660 nfc nfc
+/dev/pn553                                             0660 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/626

Depends on https://github.com/sonyxperiadev/kernel/pull/2339

Update ueventd rules for /dev/pn553 and update libnfc-nci.conf to the latest stock configuration, while also disabling verbose logging.
