### PR TITLE
[SEINE] audio_platform_info: Use voice-speaker-stereo backend for VOICE_SPEAKER

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -175,7 +175,7 @@
         <device name="SND_DEVICE_OUT_SPEAKER_EXTERNAL_2" backend="speaker-ext-2" interface="PRI_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_SPEAKER_REVERSE" backend="speaker-reverse" interface="PRI_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_SPEAKER_VBAT" backend="speaker-vbat" interface="PRI_MI2S_RX"/>
-        <device name="SND_DEVICE_OUT_VOICE_SPEAKER" backend="voice-speaker" interface="PRI_MI2S_RX"/>
+        <device name="SND_DEVICE_OUT_VOICE_SPEAKER" backend="voice-speaker-stereo" interface="PRI_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER_VBAT" backend="voice-speaker-vbat" interface="PRI_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER_2" backend="voice-speaker-2" interface="PRI_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER_2_VBAT" backend="voice-speaker-2-vbat" interface="PRI_MI2S_RX"/>


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/636

mixer_paths does not have voice-speaker paths as selected by this configuration, only voice-speaker-stereo is defined.

Stock uses this path too - despite not supporting stereo speakers at all. Instead of rewriting 12 paths in mixer_paths from voice-speaker to
voice-speaker-stereo and decreasing our ability to diff against stock and update with ease, override the appended backend.
