### PR TITLE
[master/R] Revert "seine: fstab: Enable inlinecrypt flag for data"

### DIFF
--- a/rootdir/vendor/etc/fstab.seine
+++ b/rootdir/vendor/etc/fstab.seine
@@ -12,7 +12,7 @@ vendor                                     /vendor               ext4     ro,bar
 /dev/block/by-name/oem_a                   /odm                  ext4     ro,barrier=1                                                         wait,first_stage_mount
 
 # Other partitions
-/dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic,inlinecrypt  latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata     /data                 ext4     noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic  latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent           emmc     defaults                                                             defaults
 /dev/block/bootdevice/by-name/dsp_a        /vendor/dsp           ext4     nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic          wait,notrim
 /dev/block/bootdevice/by-name/misc         /misc                 emmc     defaults                                                             defaults


### PR DESCRIPTION
This reverts commit e17b78e47c18cae3143e18d595e9c599f71acd4b.

Seine is not on CAF LA.UM.9.12 and likely won't end up there anyway.
This patch prevents properly working devices from booting with:

    E EXT4-fs (mmcblk0p86): Unrecognized mount option "inlinecrypt" or missing value
    I init    : [libfs_mgr]__mount(source=/dev/block/bootdevice/by-name/userdata,target=/data,type=ext4)=-1: Invalid argument

Reverting this patch restores normal device functionality.

CC @sjllls
