### PR TITLE
Revert "platform: Inherit gsi_keys for GSI AVB public keys"

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -252,4 +252,3 @@ TARGET_NEEDS_DTBOIMAGE ?= true
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)


### PR DESCRIPTION
**NOTE:** Needs https://github.com/sonyxperiadev/device-sony-common/pull/748 !!!

This reverts commit 71100c0085a247e93388aa9027beebe3b6e30da3.

Reason: Already defined in device-sony-common