### PR TITLE
[SEINE] [Q/R] sepolicy: Remove system_[ab] & vendor_[ab] labels for inexistant block

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -5,14 +5,11 @@
 
 /dev/block/mmcblk0                                              u:object_r:root_block_device:s0
 
-/dev/block/platform/soc/4744000\.sdhci/by-name/modemst1         u:object_r:modem_block_device:s0
-/dev/block/bootdevice/by-name/modemst1                          u:object_r:modem_block_device:s0
-
-/dev/block/platform/soc/4744000\.sdhci/by-name/modemst2         u:object_r:modem_block_device:s0
-/dev/block/bootdevice/by-name/modemst2                          u:object_r:modem_block_device:s0
-
 /dev/block/platform/soc/4744000\.sdhci/by-name/modem_[ab]       u:object_r:modem_block_device:s0
 /dev/block/bootdevice/by-name/modem_[ab]                        u:object_r:modem_block_device:s0
+
+/dev/block/platform/soc/4744000\.sdhci/by-name/modemst[12]      u:object_r:modem_block_device:s0
+/dev/block/bootdevice/by-name/modemst[12]                       u:object_r:modem_block_device:s0
 
 /dev/block/platform/soc/4744000\.sdhci/by-name/fsg              u:object_r:modem_block_device:s0
 /dev/block/bootdevice/by-name/fsg                               u:object_r:modem_block_device:s0
@@ -51,14 +48,8 @@
 /dev/block/platform/soc/4744000\.sdhci/by-name/rdimage_[ab]     u:object_r:ramdump_block_device:s0
 /dev/block/bootdevice/by-name/rdimage_[ab]                      u:object_r:ramdump_block_device:s0
 
-/dev/block/platform/soc/4744000\.sdhci/by-name/system_[ab]      u:object_r:system_block_device:s0
-/dev/block/bootdevice/by-name/system_[ab]                       u:object_r:system_block_device:s0
-
 /dev/block/platform/soc/4744000\.sdhci/by-name/oem_[ab]         u:object_r:system_block_device:s0
 /dev/block/bootdevice/by-name/oem_[ab]                          u:object_r:system_block_device:s0
-
-/dev/block/platform/soc/4744000\.sdhci/by-name/vendor_[ab]      u:object_r:system_block_device:s0
-/dev/block/bootdevice/by-name/vendor_[ab]                       u:object_r:system_block_device:s0
 
 /dev/block/platform/soc/4744000\.sdhci/by-name/abl_[ab]         u:object_r:ab_block_device:s0
 /dev/block/bootdevice/by-name/abl_[ab]                          u:object_r:ab_block_device:s0


### PR DESCRIPTION
These partitions reside on a dynamic `super` partition (together with `product`) instead of on the MMC root partition. While not harmful there's _zero_ reason to specify this.

Also unify and reorder `modemst1`/`modemst2` to match other platforms.
