### PR TITLE
[PATCH] WCNSS: Create wlan1 interface by default for concurrent STA/AP

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -91,6 +91,9 @@ EseEnabled=0
 
 ImplicitQosIsEnabled=0
 
+# Turn on STA + AP/STA
+gEnableConcurrentSTA=wlan1
+
 ################ Customize Roaming Parameters Begin ###################
 
 gNeighborScanTimerPeriod=200


### PR DESCRIPTION
Backport fix to Android Q: Configure WCNSS to expose a secondary interface, wlan1, used for
concurrent AP while wlan0 runs the STA.

Signed-off-by: Marijn Suijten <marijns95@gmail.com>