### PR TITLE
[q-mr1] platform.mk: Enable UBWC

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -226,9 +226,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.enable.cirrus.speaker=true \
     vendor.audio.offload.buffer.size.kb=32
 
-# Disable UBWC
+# Enable UBWC
 PRODUCT_PROPERTY_OVERRIDES += \
-    vendor.gralloc.disable_ubwc=1
+    vendor.gralloc.disable_ubwc=0
 
 # SurfaceFlinger
 # Keep in sync with NUM_FRAMEBUFFER_SURFACE_BUFFERS


### PR DESCRIPTION
sm6125 supports UBWC 1.0 from QCOM's document, so enable the feature.