### PR TITLE
platform.mk: Add hvdcp_opti & cdsp flags

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -90,9 +90,13 @@ TARGET_KEYMASTER_V4 := true
 # DSP
 TARGET_NEEDS_AUDIOPD := true
 TARGET_NEEDS_ADSP_SENSORS_PDR := true
+TARGET_HAS_CDSP := true
 
 # VPP
 TARGET_DISABLE_QTI_VPP := true
+
+# Hvdcp_opti
+TARGET_NEEDS_HVDCP_OPTI := true
 
 # Force building a boot image.
 # This needs to be set explicitly since Android R


### PR DESCRIPTION
#860 in common changes how those modules are enabled.
It adds flags thus we have to follow the changes into
device trees for platform and make sure the needed flags are
set.