### PR TITLE
[q-mr1] platform: Update the sys.usb.rndis.func.name to GSI

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -238,7 +238,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=4e00000.dwc3 \
-    sys.usb.rndis.func.name=rndis_bam
+    sys.usb.rndis.func.name=gsi
 
 #WiFi MAC address path
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This change enables USB GSI function driver used for
USB RMNET and RNDIS related functionalities using GSI
hardware accelerated path.

Test: USB tethering works properly now.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>