### PR TITLE
[t-mr1] platform: Disable SPU usage

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -289,6 +289,10 @@ TARGET_NEEDS_DTBOIMAGE ?= true
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.iwlan_operation_mode=legacy
 
+# Gatekeeper
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.gatekeeper.disable_spu=true
+
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)


### PR DESCRIPTION
Disable SPU (Security Processing Unit) usage because this
hardware component is not present on SoC SM6125 (Trinket).

Addresses the screen lock issue.
