### PR TITLE
[u-mr1] platform: Switch to tad_legacy

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -192,7 +192,7 @@ PRODUCT_COPY_FILES += \
 
 # Platform specific init
 PRODUCT_PACKAGES += \
-    tad.rc \
+    tad_legacy.rc \
     init.seine \
     init.seine.pwr \
     ueventd


### PR DESCRIPTION
ODM for kernel 4.19 platforms supplies legacy tad_static.